### PR TITLE
getLocalHostname and getVersion apis

### DIFF
--- a/index.js
+++ b/index.js
@@ -289,6 +289,15 @@ function SpotifyWebHelper(opts) {
 
       spotifyJsonRequest(this, '/remote/play.json', params, cb);
     }
+
+    this.getVersion = function(cb) {
+        var url = generateSpotifyUrl('/service/version.json');
+        return getJson(url, { 'service': 'remote' }, ORIGIN_HEADER, cb)
+    }
+
+    this.getLocalHostname = function() {
+      return generateRandomLocalHostName();
+    }
 }
 
 module.exports.SpotifyWebHelper = SpotifyWebHelper;


### PR DESCRIPTION
I have added two new api to get the `localhost` name for the `spotilocal` host protocol and the host current version of the application/protocol:

```
$ node
> host=require('./index')
{ SpotifyWebHelper: [Function: SpotifyWebHelper] }
> wh=new host.SpotifyWebHelper()
SpotifyWebHelper {
  isInitialized: false,
  init: [Function],
  getStatus: [Function],
  pause: [Function],
  unpause: [Function],
  play: [Function],
  getVersion: [Function],
  getLocalHostname: [Function] }
> wh.getVersion(function(err,res) { console.log(res) })
> { version: 9, client_version: '1.0.36.124.g1cba1920' }
> wh.getLocalHostname()
'gmosydwwlx.spotilocal.com'
> 
```
